### PR TITLE
Specify id-token write for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
     permissions:
       # Needed to issue the tag
       contents: write
+      id-token: write
     steps:
       - name: Checkout Streamlit code
         uses: actions/checkout@v4


### PR DESCRIPTION
Pypi upload [failed](https://github.com/streamlit/streamlit-bokeh/actions/runs/13254886428/job/37000171778) due to a misconfigured release build (of course the only step I cannot directly test).