### PR TITLE
Fix command injection vulnerability in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,12 @@ jobs:
     steps:
       - name: Check if PR was merged from a release branch
         id: check_branch
+        env:
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          if [[ "${{ github.event.pull_request.merged }}" == "true" &&
-                "${{ github.event.pull_request.head.ref }}" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ "$PR_MERGED" == "true" &&
+                "$HEAD_REF" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::set-output name=is_release::true"
           else
             echo "::set-output name=is_release::false"
@@ -126,8 +129,10 @@ jobs:
           packages-dir: dist/
 
       - name: Push Tags
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          NEW_VERSION=$(echo "${{ github.event.pull_request.head.ref }}" | sed 's/release\///')
+          NEW_VERSION=$(echo "$HEAD_REF" | sed 's/release\///')
           if [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "New version: $NEW_VERSION"
             git config --global user.email "core+streamlitbot-github@streamlit.io"


### PR DESCRIPTION
## Summary
- Fixes SNOW-3230394: OIDC token theft risk through command injection in GitHub Actions
- Moves `github.event.pull_request.head.ref` and `github.event.pull_request.merged` from direct `${{ }}` interpolation in `run:` blocks to `env:` variables in two steps:
  - The `if-release-branch` job's branch check step
  - The `release` job's "Push Tags" step
- This prevents crafted branch names from injecting arbitrary shell commands

## Why
When `${{ }}` expressions are interpolated directly in `run:` blocks, values are expanded into the shell script before execution. A malicious branch name could inject shell commands to exfiltrate OIDC tokens. Using `env:` passes values as environment variables, which the shell treats as data, not code.

## Test plan
- [ ] Verify the release workflow still triggers correctly on merged release PRs
- [ ] Confirm the branch name check and version tag push work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)