### PR TITLE
ci: run automation under Streamlit Bot instead of departed user

### DIFF
--- a/.github/repo_meta.yaml
+++ b/.github/repo_meta.yaml
@@ -1,5 +1,5 @@
 # point_of_contact: the owner of this repository, can be a GitHub user or GitHub team
-point_of_contact: "@sfc-gh-kmcgrady"
+point_of_contact: "@streamlit/eng"
 # production: whether this repository meets the criteria for being "production", see https://snowflakecomputing.atlassian.net/wiki/spaces/CLO/pages/2239988967/Production+Repository+Criteria for criteria
 production: false
 

--- a/.github/workflows/update-bokeh.yml
+++ b/.github/workflows/update-bokeh.yml
@@ -59,6 +59,11 @@ jobs:
         id: create_pr
         uses: peter-evans/create-pull-request@v6
         with:
+          # Pin the commit identity to the Streamlit Bot account. Without this,
+          # the action defaults the author to github.actor, which for a scheduled
+          # run is the last user to have edited the cron schedule.
+          author: "Streamlit Bot <core+streamlitbot-github@streamlit.io>"
+          committer: "Streamlit Bot <core+streamlitbot-github@streamlit.io>"
           branch: "release/${{ steps.compare_bokeh.outputs.new_version }}"
           base: main
           add-paths: "."


### PR DESCRIPTION
## Summary

The `Update Bokeh` scheduled workflow was attributing its generated commits to `sfc-gh-kmcgrady`, whose account has been deactivated. This repoints the automation identity at the Streamlit Bot account, matching how `streamlit/streamlit` and this repo's own `release.yml` already behave.

## Before

- Generated release commits were authored by `103003886+sfc-gh-kmcgrady@users.noreply.github.com` (see #74). `peter-evans/create-pull-request` defaults the commit author to `github.actor`, which for a scheduled run is the last user to have edited the cron schedule (a departed employee).
- `repo_meta.yaml` `point_of_contact` set to `@sfc-gh-kmcgrady`.

## After

- The create-PR step explicitly pins `author`/`committer` to `Streamlit Bot <core+streamlitbot-github@streamlit.io>`, so generated commits no longer carry an individual's name regardless of who the scheduled-run actor is.
- `repo_meta.yaml` `point_of_contact` set to `@streamlit/eng`.

No new secrets required: the PR is still opened by `github-actions[bot]` (never tied to the departed user), only the commit identity is pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)