### PR TITLE
[fix] Tear down Bokeh views before re-embedding a chart

### DIFF
--- a/e2e_playwright/bokeh_view_teardown.py
+++ b/e2e_playwright/bokeh_view_teardown.py
@@ -32,17 +32,21 @@ from streamlit_bokeh import streamlit_bokeh
 # Reruns the script; the figure is rebuilt unchanged.
 st.button("Rerun")
 
-x = [1, 2, 3, 4, 5]
-y = [6, 7, 2, 4, 5]
-
+# One large marker at the exact centre of fixed ranges, with the axes hidden so
+# the plot frame fills the canvas. A test can then hover the centre of the canvas
+# and be certain of hitting it -- no sweeping for a marker, and no way for the
+# test to quietly pass because it never found one.
 plot = figure(
     title="View teardown",
     width=400,
     height=300,
+    x_range=(0, 10),
+    y_range=(0, 10),
     toolbar_location=None,
     tools=[HoverTool(tooltips=[("x", "@x"), ("y", "@y")])],
 )
-# Large markers so a test can land the pointer on one without hunting.
-plot.scatter(x, y, size=40, fill_color="orange", line_color="navy")
+plot.axis.visible = False
+plot.grid.visible = False
+plot.scatter([5], [5], size=80, fill_color="orange", line_color="navy")
 
 streamlit_bokeh(plot, use_container_width=False, key="teardown_chart")

--- a/e2e_playwright/bokeh_view_teardown.py
+++ b/e2e_playwright/bokeh_view_teardown.py
@@ -1,0 +1,48 @@
+# Copyright (c) Snowflake Inc. (2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""App for the view-teardown regression test.
+
+A chart plus a widget that reruns the script without changing the figure, which
+is the shape that leaked views before: each rerun gives Bokeh fresh element ids,
+so the component re-embeds every time. A HoverTool is included because its
+tooltip is the visible symptom -- it attaches to document.body and is left
+behind when views are not torn down.
+
+See streamlit/streamlit#15549.
+"""
+
+import streamlit as st
+from bokeh.models import HoverTool
+from bokeh.plotting import figure
+
+from streamlit_bokeh import streamlit_bokeh
+
+# Reruns the script; the figure is rebuilt unchanged.
+st.button("Rerun")
+
+x = [1, 2, 3, 4, 5]
+y = [6, 7, 2, 4, 5]
+
+plot = figure(
+    title="View teardown",
+    width=400,
+    height=300,
+    toolbar_location=None,
+    tools=[HoverTool(tooltips=[("x", "@x"), ("y", "@y")])],
+)
+# Large markers so a test can land the pointer on one without hunting.
+plot.scatter(x, y, size=40, fill_color="orange", line_color="navy")
+
+streamlit_bokeh(plot, use_container_width=False, key="teardown_chart")

--- a/e2e_playwright/bokeh_view_teardown_test.py
+++ b/e2e_playwright/bokeh_view_teardown_test.py
@@ -63,22 +63,16 @@ def test_a_visible_tooltip_does_not_survive_a_rerun(app: Page, is_v2: bool) -> N
     canvas = app.locator("div.bk-Canvas")
     expect(canvas).to_be_visible()
 
-    # Hover a marker. The markers are large, so sweeping a few points across the
-    # canvas is enough to land on one without resolving data coordinates.
     box = canvas.bounding_box()
     assert box is not None
+    centre = (box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
     tooltip = app.locator("body > .bk-Tooltip")
 
-    for fraction_x in (0.2, 0.35, 0.5, 0.65, 0.8):
-        app.mouse.move(
-            box["x"] + box["width"] * fraction_x,
-            box["y"] + box["height"] * 0.5,
-        )
-        if tooltip.count() > 0:
-            break
-
-    if tooltip.count() == 0:
-        pytest.skip("could not land the pointer on a marker to raise a tooltip")
+    # The app puts one large marker at the centre of fixed ranges with the axes
+    # hidden, so this hits it. Asserted rather than skipped on: a test that
+    # quietly gives up when it cannot raise a tooltip is worse than no test.
+    app.mouse.move(*centre)
+    expect(tooltip).to_have_count(1)
 
     # Rerun by keyboard so the pointer never leaves the marker, which is the
     # reported situation: a tooltip up at the moment the chart is rebuilt.
@@ -88,6 +82,6 @@ def test_a_visible_tooltip_does_not_survive_a_rerun(app: Page, is_v2: bool) -> N
 
     # Move away first, so a legitimately new tooltip for the new chart cannot be
     # mistaken for the stale one.
-    app.mouse.move(box["x"] + box["width"] / 2, box["y"] - 60)
+    app.mouse.move(box["x"] + box["width"] / 2, box["y"] - 80)
 
     expect(tooltip).to_have_count(0)

--- a/e2e_playwright/bokeh_view_teardown_test.py
+++ b/e2e_playwright/bokeh_view_teardown_test.py
@@ -1,0 +1,93 @@
+# Copyright (c) Snowflake Inc. (2025)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for Bokeh view teardown across reruns.
+
+Asserts the leak rather than the symptom. `embed_item` returns a ViewManager the
+component used to discard, so every rerun added a full view tree -- along with
+the document listeners and ResizeObservers those views own -- and left hover
+tooltips attached to document.body. Counting registered root views is
+deterministic and needs no hover timing.
+
+See streamlit/streamlit#15549.
+"""
+
+import pytest
+from conftest import wait_for_app_run
+from playwright.sync_api import Page, expect
+
+_RERUNS = 4
+
+
+def _root_view_count(page: Page) -> int:
+    """Number of root views Bokeh currently has registered on the page."""
+    return page.evaluate("() => window.Bokeh?.index?.roots?.length ?? -1")
+
+
+def test_reruns_do_not_accumulate_views(app: Page, is_v2: bool) -> None:
+    if not is_v2:
+        # v1 renders each chart inside its own iframe with its own window.Bokeh,
+        # so the top-level page has no Bokeh to inspect. The leak is also
+        # confined to the iframe there, and dies with it.
+        pytest.skip("v1 renders in an iframe; Bokeh is not on the top-level page")
+
+    expect(app.locator("div.bk-Canvas")).to_be_visible()
+
+    baseline = _root_view_count(app)
+    assert baseline > 0, "expected Bokeh to have registered a root view"
+
+    for _ in range(_RERUNS):
+        app.get_by_test_id("stButton").locator("button").click()
+        wait_for_app_run(app)
+        expect(app.locator("div.bk-Canvas")).to_be_visible()
+
+        # Grew by one tree per rerun before the fix, unbounded.
+        assert _root_view_count(app) == baseline
+
+
+def test_a_visible_tooltip_does_not_survive_a_rerun(app: Page, is_v2: bool) -> None:
+    if not is_v2:
+        pytest.skip("v1 renders in an iframe; tooltips cannot escape it")
+
+    canvas = app.locator("div.bk-Canvas")
+    expect(canvas).to_be_visible()
+
+    # Hover a marker. The markers are large, so sweeping a few points across the
+    # canvas is enough to land on one without resolving data coordinates.
+    box = canvas.bounding_box()
+    assert box is not None
+    tooltip = app.locator("body > .bk-Tooltip")
+
+    for fraction_x in (0.2, 0.35, 0.5, 0.65, 0.8):
+        app.mouse.move(
+            box["x"] + box["width"] * fraction_x,
+            box["y"] + box["height"] * 0.5,
+        )
+        if tooltip.count() > 0:
+            break
+
+    if tooltip.count() == 0:
+        pytest.skip("could not land the pointer on a marker to raise a tooltip")
+
+    # Rerun by keyboard so the pointer never leaves the marker, which is the
+    # reported situation: a tooltip up at the moment the chart is rebuilt.
+    app.get_by_test_id("stButton").locator("button").focus()
+    app.keyboard.press("Enter")
+    wait_for_app_run(app)
+
+    # Move away first, so a legitimately new tooltip for the new chart cannot be
+    # mistaken for the stale one.
+    app.mouse.move(box["x"] + box["width"] / 2, box["y"] - 60)
+
+    expect(tooltip).to_have_count(0)

--- a/streamlit_bokeh/frontend/src/shared/bokeh-views.test.ts
+++ b/streamlit_bokeh/frontend/src/shared/bokeh-views.test.ts
@@ -39,17 +39,31 @@ describe("destroyViews", () => {
     expect(() => destroyViews(value)).not.toThrow()
   })
 
-  test("does not swallow an error raised by clear", () => {
-    // A failing teardown should surface rather than leave the caller believing
-    // the previous views are gone.
+  test("reports a failure inside clear without rethrowing", () => {
+    // Propagating would be worse than leaking: the caller only replaces its
+    // stored manager from the `embed_item` that follows, so a throw here leaves
+    // the old reference in place and every later render retries teardown on the
+    // same broken manager -- breaking the chart for the rest of the session
+    // rather than for one render.
     const boom = new Error("teardown failed")
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
 
-    expect(() =>
-      destroyViews({
-        clear: () => {
-          throw boom
-        },
-      })
-    ).toThrow(boom)
+    try {
+      expect(() =>
+        destroyViews({
+          clear: () => {
+            throw boom
+          },
+        })
+      ).not.toThrow()
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining("failed to tear down"),
+        boom
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
   })
 })

--- a/streamlit_bokeh/frontend/src/shared/bokeh-views.test.ts
+++ b/streamlit_bokeh/frontend/src/shared/bokeh-views.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Snowflake Inc. (2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test, vi } from "vitest"
+
+import { destroyViews } from "./bokeh-views"
+
+describe("destroyViews", () => {
+  test("clears a view manager", () => {
+    const clear = vi.fn()
+
+    destroyViews({ clear })
+
+    expect(clear).toHaveBeenCalledOnce()
+  })
+
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    // What `embed_item` would return if a future Bokeh stopped handing back a
+    // manager. Losing teardown is a slow leak; throwing would break the chart.
+    ["an object without clear", { roots: [] }],
+    ["a non-callable clear", { clear: "not a function" }],
+    ["a string", "views"],
+  ])("is a no-op for %s", (_label, value) => {
+    expect(() => destroyViews(value)).not.toThrow()
+  })
+
+  test("does not swallow an error raised by clear", () => {
+    // A failing teardown should surface rather than leave the caller believing
+    // the previous views are gone.
+    const boom = new Error("teardown failed")
+
+    expect(() =>
+      destroyViews({
+        clear: () => {
+          throw boom
+        },
+      })
+    ).toThrow(boom)
+  })
+})

--- a/streamlit_bokeh/frontend/src/shared/bokeh-views.ts
+++ b/streamlit_bokeh/frontend/src/shared/bokeh-views.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Snowflake Inc. (2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tears down the views from a previous `embed_item` call.
+ *
+ * Clearing the container element is not enough. `embed_item` builds a tree of
+ * Bokeh views, and some of them attach DOM outside the container and register
+ * listeners on `document`. Detaching the container orphans all of it:
+ *
+ *  - Hover tooltips are the visible symptom. `TooltipView._reposition` appends
+ *    to `document.body.shadowRoot ?? document.body` and calls `showPopover()`,
+ *    which promotes the element to the browser's top layer. Nothing in Bokeh
+ *    calls `hidePopover()`; the only takedown path is removing the element.
+ *  - The tooltip cannot clean itself up, because that needs a `move_exit` event
+ *    to reach the hover tool, and `UIEventBus._trigger` returns early once its
+ *    `hit_area` is disconnected. So the tooltip stays `visible: true` forever.
+ *  - Removing the element by hand does not stick. `UIElementView` observes its
+ *    own element with a `ResizeObserver`, and `_after_resize` calls
+ *    `_reposition()` -- so detaching it resizes it to 0x0, which re-appends it
+ *    and re-shows the popover. It also re-anchors against a detached target,
+ *    whose bounding box is all zeros, which is why a stale tooltip jumps to the
+ *    top-left of the viewport.
+ *  - Beyond the tooltip, every view, `document` scroll listener and
+ *    `ResizeObserver` from the previous embed stays alive. Reruns accumulate
+ *    them without bound.
+ *
+ * Bokeh already provides the teardown: `embed_item` returns the `ViewManager`
+ * for what it built, and `ViewManager.clear()` calls `remove()` on each root,
+ * which cascades through `children_views()` down to the tooltip views. This
+ * component simply discarded that return value.
+ *
+ * Call this before detaching the container, so views can unhook while their
+ * elements are still connected.
+ *
+ * See streamlit/streamlit#15549.
+ */
+
+/** The part of Bokeh's `ViewManager` this component relies on. */
+export interface BokehViewManager {
+  clear(): void
+}
+
+/**
+ * Calls `clear()` on `views` when it looks like a Bokeh `ViewManager`.
+ *
+ * Duck-typed on purpose: `embed_item`'s return value is not part of Bokeh's
+ * documented surface, so a future version could stop returning it. Losing
+ * teardown would be a slow leak; throwing on every render would break the
+ * chart outright.
+ */
+export function destroyViews(views: unknown): void {
+  const manager = views as BokehViewManager | null | undefined
+
+  if (manager != null && typeof manager.clear === "function") {
+    manager.clear()
+  }
+}

--- a/streamlit_bokeh/frontend/src/shared/bokeh-views.ts
+++ b/streamlit_bokeh/frontend/src/shared/bokeh-views.ts
@@ -43,8 +43,9 @@
  * which cascades through `children_views()` down to the tooltip views. This
  * component simply discarded that return value.
  *
- * Call this before detaching the container, so views can unhook while their
- * elements are still connected.
+ * Call this before detaching the container. Nothing in Bokeh's `remove()` path
+ * branches on whether the element is still connected, so the order is not
+ * load-bearing -- it just keeps teardown and re-embed in an obvious sequence.
  *
  * See streamlit/streamlit#15549.
  */
@@ -59,13 +60,27 @@ export interface BokehViewManager {
  *
  * Duck-typed on purpose: `embed_item`'s return value is not part of Bokeh's
  * documented surface, so a future version could stop returning it. Losing
- * teardown would be a slow leak; throwing on every render would break the
- * chart outright.
+ * teardown should be a slow leak, not a broken chart.
+ *
+ * A failure inside `clear()` is reported and swallowed for the same reason.
+ * Letting it propagate is worse than it looks: the caller assigns the new
+ * manager from the `embed_item` that follows, so a throw here means the stored
+ * reference is never replaced and every later render retries teardown on the
+ * same broken manager -- one hiccup would break the chart for the rest of the
+ * session. Degrading to the old leaky behaviour is the lesser failure.
  */
 export function destroyViews(views: unknown): void {
   const manager = views as BokehViewManager | null | undefined
 
-  if (manager != null && typeof manager.clear === "function") {
+  if (manager == null || typeof manager.clear !== "function") {
+    return
+  }
+
+  try {
     manager.clear()
+  } catch (error) {
+    // eslint-disable-next-line no-console -- a silent teardown failure would
+    // present as an unexplained leak, so leave a trace.
+    console.error("streamlit-bokeh: failed to tear down previous views", error)
   }
 }

--- a/streamlit_bokeh/frontend/src/v1/index.ts
+++ b/streamlit_bokeh/frontend/src/v1/index.ts
@@ -15,6 +15,7 @@
  */
 
 import { Streamlit, RenderData, Theme } from "streamlit-component-lib"
+import { destroyViews } from "../shared/bokeh-views"
 import { withUserIntent } from "../shared/theme-precedence"
 import { streamlitTheme } from "./streamlit-theme"
 
@@ -108,6 +109,11 @@ export const setChartThemeGenerator = () => {
 }
 const setChartTheme = setChartThemeGenerator()
 
+// Views from the last embed, kept so they can be torn down before the next one.
+// v1 renders one chart per iframe, so module scope is instance scope here, the
+// same as getChartData and setChartTheme above.
+let currentViews: unknown = null
+
 export function getChartDimensions(
   plot: any,
   useContainerWidth: boolean
@@ -158,8 +164,13 @@ async function updateChart(data: any, useContainerWidth: boolean = false) {
   }
 
   if (chart !== null) {
+    // Before the container is detached, so the previous embed's views can unhook
+    // while their elements are still connected. See shared/bokeh-views.ts.
+    destroyViews(currentViews)
+
     removeAllChildNodes(chart)
-    await window.Bokeh.embed.embed_item(data, "stBokehChart")
+
+    currentViews = await window.Bokeh.embed.embed_item(data, "stBokehChart")
   }
 }
 

--- a/streamlit_bokeh/frontend/src/v1/teardown.test.ts
+++ b/streamlit_bokeh/frontend/src/v1/teardown.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) Snowflake Inc. (2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests the v1 render path's view teardown.
+ *
+ * The e2e suite cannot cover this: v1 renders each chart inside its own iframe,
+ * so the top-level page has no `window.Bokeh` to inspect. Without these tests
+ * the v1 half of the fix has no coverage at all.
+ *
+ * v1 is a module, not a component function: it grabs `#stBokehChart` and
+ * registers a render listener at import time. So the element has to exist
+ * before the import, and the module has to be re-imported per test to reset its
+ * module-scoped state.
+ *
+ * See streamlit/streamlit#15549.
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+const FIGURE = JSON.stringify({
+  doc: { roots: [{ attributes: {} }] },
+  target_id: null,
+})
+
+const APP_THEME = {
+  base: "light",
+  primaryColor: "#ff4b4b",
+  backgroundColor: "#ffffff",
+  secondaryBackgroundColor: "#f0f2f6",
+  textColor: "#31333f",
+  font: "sans-serif",
+}
+
+/**
+ * The component-lib instance from the same module graph as the freshly imported
+ * component. `vi.resetModules()` gives the component its own copy, so a
+ * statically imported `Streamlit` would expose a different event target and the
+ * dispatch would never reach the listener.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- module namespace
+let streamlit: any
+
+const renderOnce = async (figure: string): Promise<void> => {
+  streamlit.Streamlit.events.dispatchEvent(
+    new CustomEvent(streamlit.Streamlit.RENDER_EVENT, {
+      detail: {
+        disabled: false,
+        theme: APP_THEME,
+        args: {
+          figure,
+          // A built-in theme: the Streamlit theme reads CSS custom properties
+          // jsdom does not resolve, and theming is not what these tests cover.
+          bokeh_theme: "caliber",
+          use_container_width: false,
+        },
+      },
+    })
+  )
+  // The listener is async and awaits embed_item; drain the microtask queue.
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+describe("v1 view teardown", () => {
+  let managers: { clear: ReturnType<typeof vi.fn> }[]
+
+  beforeEach(async () => {
+    // Must exist before the import: the module captures it at load time.
+    document.body.innerHTML = '<div id="stBokehChart"></div>'
+
+    managers = []
+    window.Bokeh.embed = {
+      embed_item: vi.fn(async () => {
+        const manager = { clear: vi.fn() }
+        managers.push(manager)
+        return manager
+      }),
+    }
+
+    // Fresh module per test, so the module-scoped view reference resets.
+    vi.resetModules()
+    streamlit = await import("streamlit-component-lib")
+    await import("./index")
+  })
+
+  test("does not tear anything down on a first render", async () => {
+    await renderOnce(FIGURE)
+
+    expect(managers).toHaveLength(1)
+    expect(managers[0].clear).not.toHaveBeenCalled()
+  })
+
+  test("tears down the previous embed's views before re-embedding", async () => {
+    await renderOnce(FIGURE)
+    await renderOnce(JSON.stringify({ ...JSON.parse(FIGURE), rerun: 1 }))
+
+    expect(managers).toHaveLength(2)
+    expect(managers[0].clear).toHaveBeenCalledOnce()
+    expect(managers[1].clear).not.toHaveBeenCalled()
+  })
+
+  test("keeps working when a teardown fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
+
+    try {
+      await renderOnce(FIGURE)
+      managers[0].clear.mockImplementation(() => {
+        throw new Error("teardown failed")
+      })
+
+      await renderOnce(JSON.stringify({ ...JSON.parse(FIGURE), rerun: 1 }))
+      await renderOnce(JSON.stringify({ ...JSON.parse(FIGURE), rerun: 2 }))
+
+      expect(window.Bokeh.embed.embed_item).toHaveBeenCalledTimes(3)
+      expect(managers[0].clear).toHaveBeenCalledOnce()
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+})

--- a/streamlit_bokeh/frontend/src/v2/index.ts
+++ b/streamlit_bokeh/frontend/src/v2/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { destroyViews } from "../shared/bokeh-views"
 import { withUserIntent } from "../shared/theme-precedence"
 import { MinimalStreamlitTheme, streamlitTheme } from "./streamlit-theme"
 
@@ -145,8 +146,9 @@ async function updateChart(
   useContainerWidth: boolean = false,
   chart: HTMLDivElement,
   parentElement: HTMLElement,
-  key: string
-) {
+  key: string,
+  previousViews: unknown
+): Promise<unknown> {
   /**
    * When you create a bokeh chart in your python script, you can specify
    * the width: p = figure(title="simple line example", x_axis_label="x", y_axis_label="y", plot_width=200);
@@ -173,8 +175,13 @@ async function updateChart(
     }
   }
 
+  // Before the container is detached, so the previous embed's views can unhook
+  // while their elements are still connected. See shared/bokeh-views.ts.
+  destroyViews(previousViews)
+
   removeAllChildNodes(chart)
-  await window.Bokeh.embed.embed_item(data, key)
+
+  return window.Bokeh.embed.embed_item(data, key)
 }
 
 interface ComponentData {
@@ -208,6 +215,8 @@ type ComponentState = {
   initialized: boolean
   setChartTheme: ReturnType<typeof setChartThemeGenerator>
   getChartData: ReturnType<typeof getChartDataGenerator>
+  /** Views from this instance's last embed, kept so they can be torn down. */
+  views: unknown
 }
 
 const componentState = new WeakMap<HTMLElement | ShadowRoot, ComponentState>()
@@ -222,6 +231,7 @@ const getOrCreateInstanceState = (
       initialized: false,
       setChartTheme: setChartThemeGenerator(),
       getChartData: getChartDataGenerator(),
+      views: null,
     }
     componentState.set(host, state)
   }
@@ -281,11 +291,22 @@ const bokehComponent = async (component: ComponentArgs<{}, ComponentData>) => {
   // The only exception would be if the same info is sent down from the frontend
   // only. It shouldn't happen, but it's a safeguard.
   if (hasChanged || themeChanged) {
-    await updateChart(chartData, useContainerWidth, chart, container, key)
+    state.views = await updateChart(
+      chartData,
+      useContainerWidth,
+      chart,
+      container,
+      key,
+      state.views
+    )
   }
 
   return () => {
-    // Cleanup the instance state
+    // Unmounting detaches the container, which would orphan this instance's
+    // views and any DOM they attached elsewhere -- a visible tooltip would
+    // survive the component and outlive page navigation.
+    destroyViews(state.views)
+    state.views = null
     componentState.delete(parentElement)
   }
 }

--- a/streamlit_bokeh/frontend/src/v2/teardown.test.ts
+++ b/streamlit_bokeh/frontend/src/v2/teardown.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) Snowflake Inc. (2025)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests the v2 render path's view teardown, which the e2e suite covers only
+ * end-to-end. Mocking `./loaders` is what makes the component reachable from a
+ * unit test at all -- otherwise importing it tries to append real <script> tags
+ * for the Bokeh bundles.
+ *
+ * See streamlit/streamlit#15549.
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+vi.mock("./loaders", () => ({
+  loadBokehGlobally: vi.fn(async () => undefined),
+}))
+
+// eslint-disable-next-line import/first -- must follow the mock above.
+import bokehComponent from "./index"
+
+const FIGURE = JSON.stringify({
+  doc: { roots: [{ attributes: {} }] },
+  target_id: null,
+})
+
+/** A fresh host element, since instance state is keyed on it by WeakMap. */
+const makeHost = (): HTMLElement => {
+  const host = document.createElement("div")
+  const container = document.createElement("div")
+  container.className = "stBokehContainer"
+  host.appendChild(container)
+  document.body.appendChild(host)
+  return host
+}
+
+const render = (host: HTMLElement, figure: string) =>
+  bokehComponent({
+    parentElement: host,
+    key: "chart",
+    data: {
+      figure,
+      // A built-in theme rather than "streamlit": the Streamlit theme reads CSS
+      // custom properties that jsdom does not resolve, and theming is not what
+      // these tests are about.
+      bokeh_theme: "caliber",
+      use_container_width: false,
+      key: "chart",
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- the host's
+    // full ComponentArgs surface is irrelevant here.
+  } as any)
+
+describe("v2 view teardown", () => {
+  let managers: { clear: ReturnType<typeof vi.fn> }[]
+
+  beforeEach(() => {
+    document.body.innerHTML = ""
+    managers = []
+    window.Bokeh.embed = {
+      embed_item: vi.fn(async () => {
+        const manager = { clear: vi.fn() }
+        managers.push(manager)
+        return manager
+      }),
+    }
+  })
+
+  test("does not tear anything down on a first render", async () => {
+    await render(makeHost(), FIGURE)
+
+    expect(window.Bokeh.embed.embed_item).toHaveBeenCalledOnce()
+    expect(managers).toHaveLength(1)
+    expect(managers[0].clear).not.toHaveBeenCalled()
+  })
+
+  test("tears down the previous embed's views before re-embedding", async () => {
+    const host = makeHost()
+
+    await render(host, FIGURE)
+    // A rerun sends a different figure, because each script run gives Bokeh
+    // fresh element ids.
+    await render(host, JSON.stringify({ ...JSON.parse(FIGURE), rerun: 1 }))
+
+    expect(managers).toHaveLength(2)
+    expect(managers[0].clear).toHaveBeenCalledOnce()
+    expect(managers[1].clear).not.toHaveBeenCalled()
+  })
+
+  test("keeps working when a teardown fails, instead of wedging the chart", async () => {
+    const host = makeHost()
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined)
+
+    try {
+      await render(host, FIGURE)
+      managers[0].clear.mockImplementation(() => {
+        throw new Error("teardown failed")
+      })
+
+      await render(host, JSON.stringify({ ...JSON.parse(FIGURE), rerun: 1 }))
+      await render(host, JSON.stringify({ ...JSON.parse(FIGURE), rerun: 2 }))
+
+      // Re-embedded both times rather than retrying the broken manager forever.
+      expect(window.Bokeh.embed.embed_item).toHaveBeenCalledTimes(3)
+      expect(managers[0].clear).toHaveBeenCalledOnce()
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  test("tears down on unmount, so nothing outlives the component", async () => {
+    const host = makeHost()
+
+    const cleanup = await render(host, FIGURE)
+    expect(managers[0].clear).not.toHaveBeenCalled()
+
+    cleanup?.()
+
+    expect(managers[0].clear).toHaveBeenCalledOnce()
+  })
+
+  test("keeps two instances independent", async () => {
+    const first = makeHost()
+    const second = makeHost()
+
+    await render(first, FIGURE)
+    await render(second, FIGURE)
+    // Rerun only the first instance.
+    await render(first, JSON.stringify({ ...JSON.parse(FIGURE), rerun: 1 }))
+
+    expect(managers).toHaveLength(3)
+    // The first instance's original views went; the second's are untouched.
+    expect(managers[0].clear).toHaveBeenCalledOnce()
+    expect(managers[1].clear).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes streamlit/streamlit#15549: a Bokeh hover tooltip visible when Streamlit reruns stays on screen, survives navigation to other pages, and only clears on a hard refresh.

`embed_item` returns the `ViewManager` for what it built, and this component discarded it — so every rerun orphaned the previous view tree. The tooltip is the visible symptom of a broader leak: measured across seven embeds in a real browser, root views went **2, 4, 6, 8, 10, 12, 14**, live `ResizeObserver`s **8, 16, 24, …**, and `document` scroll listeners **1, 2, 3, …**. All three stay flat with the fix.

## Why the tooltip in particular

Three things compound, all verified against the shipped `bokeh-3.10.0.min.js`:

- `TooltipView._reposition` appends the tooltip to `document.body`, not the plot container, and shows it via the Popover API. `hidePopover` appears **zero** times in Bokeh — the only takedown is removing the element.
- It cannot self-clean: that needs a `move_exit` to reach the hover tool, and `UIEventBus._trigger` returns early once its `hit_area` is disconnected, which detaching the container guarantees.
- Removing the element by hand doesn't stick. `UIElementView` observes its *own* element with a `ResizeObserver`, and `_after_resize` calls `_reposition()` — so detaching resizes it to 0×0, which re-appends it. It also re-anchors against a detached target whose bounding box is zeros, which is why a stale tooltip lands top-left, as in the issue's screenshot.

So **sweeping `document.body > .bk-Tooltip` does not work**, and was verified not to. That's the obvious fix, and the leaked view undoes it.

## The fix

Keep the `ViewManager` — per instance in v2's `ComponentState`, module-scoped in v1 — and `clear()` it before detaching the container. v2's cleanup callback clears too; unmounting leaked the same way, which is how a tooltip outlived page navigation.

`destroyViews` is duck-typed on `clear` and reports rather than rethrows a failure inside it. `embed_item`'s return value isn't documented surface, so losing teardown should degrade to a leak, not a broken chart — and rethrowing was worse: the caller only replaces its stored manager from the `embed_item` that follows, so a throw meant retrying the same broken manager for the rest of the session.

## Worth a reviewer's attention

This changes teardown for **every** chart on every rerun, not just ones with tooltips. That breadth is what makes it durable rather than cosmetic, but the existing snapshot suite is the safety net for ordinary rendering.

## Testing

**73 frontend unit tests.** `destroyViews` covers the happy path, wrong-shape no-ops, and degradation on failure. New wiring tests cover both entrypoints: first render, teardown before re-embed, surviving a failed teardown, plus unmount and two independent instances for v2. Verified they discriminate — 4 of 5 fail in v2 and 2 of 3 in v1 with the fix neutered, the rest being first-render invariants that hold either way.

The wiring had no unit coverage before this; mocking `./loaders` is what makes the v2 component reachable at all. That matters most for **v1**, whose 13 changed lines had no coverage of any kind, since the e2e tests are v2-only — v1 renders each chart in its own iframe, so the top-level page has no `window.Bokeh`.

**E2E**, v2-only: one test asserts the leak (root view count constant across reruns, no hover timing involved), one covers the reported case, rerunning by keyboard so the pointer never leaves the marker.

Verified against the issue's **actual repro** — the 8-subplot `gridplot` with 10,000 points and eight `HoverTool`s — in real Chromium: 2 stale tooltips survive teardown without the fix and 0 with it, root views `4, 6, 8, 10` versus flat `2`. That exercises teardown cascading from a GridPlot root through 8 child plots to 8 hover tools, which the single-figure tests can't show.

Both e2e tests run in CI on the v2 leg (`streamlit 1.63.0 -> Custom Component v2`, 77 passed) and skip on the v1 leg by design. They were also verified locally in both directions across **chromium, firefox and webkit** — 11 runs, no flakes — passing with the fix and failing without it (`expected count '0', actual '1'`, the stale tooltip surviving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
