### PR TITLE
[fix] Register the component lazily, and give each Streamlit matrix leg its own venv

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -104,7 +104,6 @@ jobs:
           else
             pip install "streamlit==${{ matrix.streamlit }}"
           fi
-          python -m playwright install --with-deps
       - name: Verify the Streamlit version under test
         env:
           MATRIX_STREAMLIT: ${{ matrix.streamlit }}
@@ -127,10 +126,14 @@ jobs:
                   f"resolved to streamlit {installed}"
               )
           else:
-              assert installed == wanted, (
+              assert Version(installed) == Version(wanted), (
                   f"this leg should test streamlit {wanted}, but {installed} is installed"
               )
           EOF
+      - name: Install Playwright browsers
+        run: |
+          source venv/bin/activate
+          python -m playwright install --with-deps
       - name: Run playwright tests
         run: |
           source venv/bin/activate

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -74,6 +74,11 @@ jobs:
           md5sum e2e_playwright/test-requirements.txt >> $GITHUB_WORKSPACE/python_cache_key.md5
           md5sum pyproject.toml >> $GITHUB_WORKSPACE/python_cache_key.md5
           date +%F >> $GITHUB_WORKSPACE/python_cache_key.md5
+          # Each matrix leg needs its own venv. Without this the legs share one
+          # cache entry, so whichever runs first decides the Streamlit version
+          # for both -- and the leg meant to test Custom Component v2 silently
+          # ran v1 instead.
+          echo "streamlit=${{ matrix.streamlit }}" >> $GITHUB_WORKSPACE/python_cache_key.md5
         shell: bash
       - name: Restore virtualenv from cache
         id: cache-virtualenv
@@ -93,11 +98,39 @@ jobs:
           pip install --upgrade pip
           pip install -r e2e_playwright/test-requirements.txt
           if [[ "${{ matrix.streamlit }}" == "latest" ]]; then
-            pip install streamlit
+            # -U matters: plain `pip install streamlit` is a no-op when any
+            # version is already present, so a restored venv would keep its own.
+            pip install -U streamlit
           else
             pip install "streamlit==${{ matrix.streamlit }}"
           fi
           python -m playwright install --with-deps
+      - name: Verify the Streamlit version under test
+        env:
+          MATRIX_STREAMLIT: ${{ matrix.streamlit }}
+        run: |
+          source venv/bin/activate
+          python - <<'EOF'
+          import os
+          import streamlit
+          from packaging.version import Version
+
+          wanted = os.environ["MATRIX_STREAMLIT"]
+          installed = streamlit.__version__
+          # streamlit-bokeh switches to Custom Component v2 at 1.51.0.
+          api = "v2" if Version(installed) >= Version("1.51.0") else "v1"
+          print(f"streamlit {installed} -> Custom Component {api}")
+
+          if wanted == "latest":
+              assert Version(installed) >= Version("1.51.0"), (
+                  f"this leg exists to test Custom Component v2, but 'latest' "
+                  f"resolved to streamlit {installed}"
+              )
+          else:
+              assert installed == wanted, (
+                  f"this leg should test streamlit {wanted}, but {installed} is installed"
+              )
+          EOF
       - name: Run playwright tests
         run: |
           source venv/bin/activate

--- a/e2e_playwright/theme_validation_test.py
+++ b/e2e_playwright/theme_validation_test.py
@@ -24,6 +24,8 @@ only ever passes valid names, so the rejection path never executes.
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 
 import bokeh
@@ -113,3 +115,29 @@ def test_validation_is_wired_into_the_public_function() -> None:
 
     with pytest.raises(StreamlitAPIException, match="Invalid `theme` value"):
         streamlit_bokeh.streamlit_bokeh(plot, theme="carbon")
+
+
+def test_the_package_imports_without_a_streamlit_runtime() -> None:
+    """Importing must not require a running Streamlit runtime.
+
+    Registering a file-backed Custom Component v2 resolves its assets through
+    Streamlit's component manager, and with no runtime
+    `get_bidi_component_manager()` returns a fresh, empty manager on every call
+    -- so registration raises and the import fails. That is why registration is
+    deferred to first use.
+
+    This is checked in a subprocess because the test session has already
+    imported the module. Without the deferral, every test in this file fails as
+    a collection error instead, which reports the cause far less clearly.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", "import streamlit_bokeh"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=_REPO_ROOT.parent,
+    )
+
+    assert (
+        result.returncode == 0
+    ), f"importing streamlit_bokeh without a Streamlit runtime failed:\n{result.stderr}"

--- a/streamlit_bokeh/__init__.py
+++ b/streamlit_bokeh/__init__.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import importlib.metadata
 import json
 import os
+import threading
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -62,6 +63,11 @@ _IS_USING_UPDATED_ISOLATE_STYLES_PARAM = Version(_STREAMLIT_VERSION) >= Version(
 # Registering on first call instead means the runtime always exists by the time
 # it happens, since the component can only render inside a script run.
 _component_func: Callable[..., Any] | None = None
+# Streamlit runs each session's script in its own thread, so first calls can
+# race. Registering twice is harmless -- Streamlit's registry overwrites by name
+# under its own lock -- but without this each racing thread would redo the glob
+# resolution and path validation for the same result.
+_component_func_lock = threading.Lock()
 
 
 def _create_component_func() -> Callable[..., Any]:
@@ -98,7 +104,10 @@ def _get_component_func() -> Callable[..., Any]:
     global _component_func
 
     if _component_func is None:
-        _component_func = _create_component_func()
+        with _component_func_lock:
+            # Re-checked inside the lock: another thread may have won the race.
+            if _component_func is None:
+                _component_func = _create_component_func()
 
     return _component_func
 

--- a/streamlit_bokeh/__init__.py
+++ b/streamlit_bokeh/__init__.py
@@ -50,36 +50,57 @@ _IS_USING_UPDATED_ISOLATE_STYLES_PARAM = Version(_STREAMLIT_VERSION) >= Version(
     "1.53.0"
 )
 
-# Version-gated component registration
-_component_func: Callable[..., Any]
+# Version-gated component registration, deferred to first use.
+#
+# Registering a file-backed Custom Component v2 resolves its assets through
+# Streamlit's component manager, and outside a running Streamlit runtime
+# `get_bidi_component_manager()` hands back a fresh, empty manager -- so the
+# asset root is never found and registration raises. Doing this at import time
+# therefore made `import streamlit_bokeh` fail anywhere there is no runtime: a
+# plain script, a notebook, or a test that only wants the module's helpers.
+#
+# Registering on first call instead means the runtime always exists by the time
+# it happens, since the component can only render inside a script run.
+_component_func: Callable[..., Any] | None = None
 
-if _IS_USING_CCV2:
-    # Streamlit 1.53+ accepts isolate_styles in the `component(...)` call.
-    if _IS_USING_UPDATED_ISOLATE_STYLES_PARAM:
-        _component_func = st.components.v2.component(
+
+def _create_component_func() -> Callable[..., Any]:
+    """Registers the component with Streamlit and returns its callable."""
+    if _IS_USING_CCV2:
+        # Streamlit 1.53+ accepts isolate_styles in the `component(...)` call.
+        if _IS_USING_UPDATED_ISOLATE_STYLES_PARAM:
+            return st.components.v2.component(
+                name="streamlit-bokeh.streamlit_bokeh",
+                js="v2/index-*.mjs",
+                html="<div class='stBokehContainer'></div>",
+                isolate_styles=_ISOLATE_STYLES,
+            )
+
+        return st.components.v2.component(
             name="streamlit-bokeh.streamlit_bokeh",
             js="v2/index-*.mjs",
             html="<div class='stBokehContainer'></div>",
-            isolate_styles=_ISOLATE_STYLES,
         )
-    else:
-        _component_func = st.components.v2.component(
-            name="streamlit-bokeh.streamlit_bokeh",
-            js="v2/index-*.mjs",
-            html="<div class='stBokehContainer'></div>",
-        )
-else:
+
     if not _RELEASE:
-        _component_func = st.components.v1.declare_component(
+        return st.components.v1.declare_component(
             "streamlit_bokeh",
             url="http://localhost:3001",
         )
-    else:
-        parent_dir = os.path.dirname(os.path.abspath(__file__))
-        build_dir = os.path.join(parent_dir, "frontend/build")
-        _component_func = st.components.v1.declare_component(
-            "streamlit_bokeh", path=build_dir
-        )
+
+    parent_dir = os.path.dirname(os.path.abspath(__file__))
+    build_dir = os.path.join(parent_dir, "frontend/build")
+    return st.components.v1.declare_component("streamlit_bokeh", path=build_dir)
+
+
+def _get_component_func() -> Callable[..., Any]:
+    """Returns the component callable, registering it on first use."""
+    global _component_func
+
+    if _component_func is None:
+        _component_func = _create_component_func()
+
+    return _component_func
 
 
 __version__ = importlib.metadata.version("streamlit_bokeh")
@@ -203,16 +224,16 @@ def streamlit_bokeh(
         # Streamlit 1.51-1.52 accepts isolate_styles on the returned component
         # function (it moved to `component(...)` in 1.53).
         if not _IS_USING_UPDATED_ISOLATE_STYLES_PARAM:
-            _component_func(key=key, data=data, isolate_styles=_ISOLATE_STYLES)
+            _get_component_func()(key=key, data=data, isolate_styles=_ISOLATE_STYLES)
         else:
-            _component_func(key=key, data=data)
+            _get_component_func()(key=key, data=data)
 
         return None
     else:
         # Call through to our private component function. Arguments we pass here
         # will be sent to the frontend, where they'll be available in an "args"
         # dictionary.
-        _component_func(
+        _get_component_func()(
             figure=json.dumps(json_item(figure)),
             use_container_width=use_container_width,
             bokeh_theme=theme,


### PR DESCRIPTION
## Summary

Two fixes with one origin: **`main` is red**, and the e2e leg meant to test Custom Component v2 has never actually tested it.

**The import failure.** Registering a file-backed v2 component resolves its assets through `get_bidi_component_manager()`, which with no Streamlit runtime returns a fresh, empty manager *on every call* — so the asset root is never found and registration raises. Because we registered at import time, `import streamlit_bokeh` failed anywhere without a runtime: a script, a notebook, or a test. The declaration was fine all along; `scan_component_manifests()` finds it correctly. Registration is now deferred to first use, where a runtime necessarily exists.

That is what broke `main`: the #78 merge commit hit a cache miss, installed Streamlit 1.63.0, and `theme_validation_test.py` aborted collection.

**The matrix leg.** The venv cache key omitted `matrix.streamlit`, so both legs shared one entry and whichever ran first decided the Streamlit version for both. The install step couldn't correct it, because `pip install streamlit` is a no-op when any version is present (only `-U` moves it). With a 1.50.0 venv restored, the `latest` leg ran the **v1** path, every v2-gated test skipped, and the `-v2` snapshots went unexercised — invisibly, since both baseline variants are committed. Fixed by adding the leg to the cache key and `-U` to the install.

## Guards

- A CI step asserts the installed Streamlit matches the leg's purpose: pinned must match exactly, `latest` must be ≥ 1.51.0. Otherwise the job fails saying so.
- A test asserts the package imports without a runtime, in a subprocess — because the failure that reached `main` was a collection error that aborts everything and names the cause poorly.

## Verification

Isolated venv, real Chromium, both APIs — Streamlit 1.50.0 (v1) and 1.63.0 (v2): bare import, the 17 validation tests, and chart rendering all pass. Previously the import and those tests failed on v2. Confirmed the new guard fails without the deferral.


## Alternatives, for the reviewer to weigh

Deferring registration fixes the broken test *and* makes the package importable in plain Python — a script, a notebook, `python -c "import streamlit_bokeh"`, import linters. But no user has reported that second problem; I inferred it. A reasonable position is "don't change library initialization to satisfy a test." So the options, with what I checked:

| | |
|---|---|
| **Defer registration** (this PR) | Fixes the test and the import defect. |
| **`streamlit.testing.v1.AppTest`** | Verified working — builds a mock runtime with a populated manager. Changes only the test, leaves the import defect in place. |
| **Test through an app** | An e2e app that calls `streamlit_bokeh(fig, theme="carbon")` and asserts the rendered error. No bare import at all. |
| **Upstream in Streamlit** | `get_bidi_component_manager()` returning a throwaway manager makes *any* file-backed component unimportable outside a runtime. Worth raising whichever option we take — none of the others make it unnecessary. |

Ruled out, so they don't get re-proposed: extracting validation to a submodule (importing a submodule imports the parent, so registration still fires — confirmed); importing inside the test functions (the import fails whenever it happens without a runtime); and inlining the JS as Streamlit's own examples do (our bundle is too large, and we would lose asset serving — this is why those examples never hit this).

Worth noting that Streamlit's examples register at import time only with **inline** JS, which returns early and never resolves an asset root. There is no documented guidance on where to call `component()` for file-backed assets, so the import-time pattern here was undocumented territory rather than a sanctioned one.

## Expected consequence

The `latest` leg will exercise v2 for the first time. Any `-v2` snapshot failures are pre-existing on `main`, not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

